### PR TITLE
[Add]2nd_test 実装フェーズ2テスト

### DIFF
--- a/app/controllers/admin/searches_controller.rb
+++ b/app/controllers/admin/searches_controller.rb
@@ -6,7 +6,7 @@ class Admin::SearchesController < ApplicationController
     
     if @model == "user"
       # 投稿住所検索は新着順に表示
-      @records = User.search_for(@content).page(params[:page]).per(8)
+      @records = User.admin_search_for(@content).page(params[:page]).per(8)
     else
       @records = Post.search_for(@content, @model).page(params[:page]).per(8).order('id DESC')
     end

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -22,6 +22,7 @@ class Admin::UsersController < ApplicationController
       else
         flash[:notice] = "ユーザー情報を更新しました。"
         @user.posts.destroy_all
+        @user.post_comments.destroy_all
       end
       redirect_to admin_user_path(@user.id)
     else
@@ -32,7 +33,7 @@ class Admin::UsersController < ApplicationController
 
   def userpost
     @user = User.find(params[:id])
-    @posts = @user.posts.page(params[:page]).per(10)
+    @posts = @user.posts.page(params[:page]).per(10).order('id DESC')
   end
 
   private

--- a/app/controllers/public/users_controller.rb
+++ b/app/controllers/public/users_controller.rb
@@ -7,12 +7,12 @@ class Public::UsersController < ApplicationController
     # 新着順
     @posts = @user.posts.page(params[:page]).per(8).order('id DESC')
   end
-  
+
   def edit
     @current_user = current_user
     @user = current_user
   end
-  
+
   def update
     @user = current_user
     if @user.update(user_params)
@@ -27,18 +27,19 @@ class Public::UsersController < ApplicationController
   def unsubscribe
     @current_user = current_user
   end
-  
+
   def withdraw
     current_user.update(is_active: false)
     # ユーザが退会ステータスになったらユーザの投稿は削除される
     current_user.posts.destroy_all
+    current_user.post_comments.destroy_all
     reset_session
     flash[:notice] = "退会処理をしました。ご利用ありがとうございました。"
     redirect_to new_user_registration_path
   end
-  
+
   private
-  
+
   def user_params
     params.require(:user).permit(:name, :profile_image, :email, :introduction)
   end
@@ -49,5 +50,5 @@ class Public::UsersController < ApplicationController
       redirect_to user_path(current_user.id)
     end
   end
-  
+
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -22,8 +22,12 @@ class User < ApplicationRecord
     profile_image.variant(resize: "#{width}x#{height}!").processed
   end
   
-  # 検索機能(部分検索のみ)
+  # ユーザー用検索機能(部分検索でステータスが有効のみ)
   def self.search_for(content)
+    User.where('name LIKE ?', '%' + content + '%').where(is_active: true)
+  end
+  # 管理者用検索機能(部分検索でステータスが有効・無効どちらでも検索可能)
+  def self.admin_search_for(content)
     User.where('name LIKE ?', '%' + content + '%')
   end
     

--- a/app/views/admin/users/_index.html.erb
+++ b/app/views/admin/users/_index.html.erb
@@ -1,7 +1,7 @@
 <table class="table border-bottom table-hover table-inverse">
   <thead>
     <tr>
-      <th class="text-center">ID</th>
+      <th class="text-center">ユーザーID</th>
       <th class="text-center">ユーザー名</th>
       <th class="text-center">アドレス</th>
       <th class="text-center">ステータス</th>

--- a/app/views/public/users/_index.html.erb
+++ b/app/views/public/users/_index.html.erb
@@ -11,7 +11,8 @@
         </td>
         <td class="align-middle">
           <i class="fa-solid fa-message" style="color: #7a7a7a;"></i>
-          <%= user.introduction %>
+          <!--ユーザのメッセージ-->
+          <%= render 'public/users/message', user: user %>
         </td>
       </tr>
     <% end %>


### PR DESCRIPTION
修正点
①ユーザー側：検索機能でユーザーを検索した際にメッセージが登録されていなかったら空白で表示されていたのを、「メッセージはありません」と表示されるように設定
②ユーザー側：検索機能で退会したユーザーも検索結果で表示されていたので、非表示に設定(モデルの定義をadminとuserで変更した)
③管理者側：ユーザーの投稿一覧ページが投稿日時が古い順に並んでいたため、最新順に変更
④ユーザー・管理者両方：退会処理をしたユーザーが投稿に対してコメントした内容が削除されていなかったため、ユーザー側・管理者側どちらでも退会処理をした場合、削除されるように修正
