### PR TITLE
[Fix]timeline　タイムラインとマップ機能の修正

### DIFF
--- a/app/controllers/public/posts_controller.rb
+++ b/app/controllers/public/posts_controller.rb
@@ -53,11 +53,12 @@ class Public::PostsController < ApplicationController
   end
 
   def timeline
+    
     respond_to do |format|
       format.html do
         # 後でフォローしている人と自分の投稿のみ表示にする
         # 新着順
-        @posts = Post.page(params[:page]).per(10).order('id DESC')
+        @posts = Post.where(user_id: [current_user.id] + current_user.followings.pluck(:id)).page(params[:page]).per(10).order('id DESC')
       end
       format.json do
         @posts = Post.all

--- a/app/controllers/public/registrations_controller.rb
+++ b/app/controllers/public/registrations_controller.rb
@@ -40,9 +40,9 @@ class Public::RegistrationsController < Devise::RegistrationsController
 
   # 遷移先をマップへ変更すること
   def after_sign_in_path_for(resource)
-    map_path
+    user_path(current_user.id)
   end
-  
+
   def after_sign_out_path_for(resource)
     root_path
   end

--- a/app/controllers/public/sessions_controller.rb
+++ b/app/controllers/public/sessions_controller.rb
@@ -23,13 +23,13 @@ class Public::SessionsController < Devise::SessionsController
 
   # 遷移先をマップへ変更すること
   def after_sign_in_path_for(resource)
-    map_path
+    user_path(current_user.id)
   end
 
   def after_sign_out_path_for(resource)
     root_path
   end
-  
+
   # ゲストログイン機能
   def guest_sign_in
     user = User.guest
@@ -48,7 +48,7 @@ class Public::SessionsController < Devise::SessionsController
       redirect_to new_user_registration_path, notice: '退会済みのため、再度新規登録が必要です。'
     end
   end
-  
+
   # protected
 
   # If you have extra params to permit, append them to the sanitizer.

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -7,8 +7,7 @@
     <%= csp_meta_tag %>
 
     <script src="https://kit.fontawesome.com/0e58e38434.js" crossorigin="anonymous"></script>
-    <!--jquery-jpostal-js-->
-    <script src="https://cdn.jsdelivr.net/npm/jquery-jpostal-ja@2.14.45/jquery.jpostal.min.js"></script>
+
     <%= stylesheet_pack_tag 'application', media: 'all', 'data-turbolinks-track': 'reload' %>
     <%= javascript_pack_tag 'application', 'data-turbolinks-track': 'reload' %>
   </head>
@@ -24,5 +23,7 @@
     <footer>
       <%= render "layouts/footer" %>
     </footer>
+    <!--jquery-jpostal-js-->
+    <script src="https://cdn.jsdelivr.net/npm/jquery-jpostal-ja@2.14.45/jquery.jpostal.min.js"></script>
   </body>
 </html>

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -36,30 +36,30 @@ end
 # 投稿画像を変更すること
 post = taro.posts.create!(
   image: ActiveStorage::Blob.create_and_upload!(io: File.open(Rails.root.join("app/assets/images/default-image.jpg")),filename: 'default-image.jpg'),
-  post_code: '7008544',
+  post_code: '7000913',
   prefecture_address: '岡山県',
   city_address: '岡山市北区',
-  block_address: '大供１－１',
+  block_address: '大供〇－〇',
   detail: 'ここは柵がなくて危険です！近くを通るときはお気を付けください。',
   status: 0
 )
 
 hanako.posts.create!(
   image: ActiveStorage::Blob.create_and_upload!(io: File.open(Rails.root.join("app/assets/images/default-image.jpg")),filename: 'default-image.jpg'),
-  post_code: '7000023',
+  post_code: '7000024',
   prefecture_address: '岡山県',
   city_address: '岡山市北区',
-  block_address: '駅元町１－１',
+  block_address: '駅元町〇－〇',
   detail: 'ここは柵がなく危険でしたが、昨日柵が設置されました！',
   status: 1
 )
 
 jiro.posts.create!(
   image: ActiveStorage::Blob.create_and_upload!(io: File.open(Rails.root.join("app/assets/images/default-image.jpg")),filename: 'default-image.jpg'),
-  post_code: '7038544',
+  post_code: '7100833',
   prefecture_address: '岡山県',
-  city_address: '岡山市中区',
-  block_address: '浜三丁目７番１５号',
+  city_address: '倉敷市',
+  block_address: '西中新田〇－〇',
   detail: 'ここの用水路は学生の通学路ですが柵がありません。水深が深く転落すると非常に危険です。',
   status: 0
 )


### PR DESCRIPTION
①タイムラインの表示をフォロー済のユーザーと自分の投稿のみに限定
②マップ機能のバグについて
マップ機能をログイン後の遷移先に設定していると、全ユーザーのユーザー画像を取得できないため遷移先をマイページへ変更。
seedのみは元からデータを入れているのでマイページでログイン情報を取得できない。本番環境実装の初めに検索機能などでユーザー画像を取得すればその後は通常に表示される。