### PR TITLE
[Fix]アクセス権限

### DIFF
--- a/app/controllers/admin/posts_controller.rb
+++ b/app/controllers/admin/posts_controller.rb
@@ -4,6 +4,7 @@ class Admin::PostsController < ApplicationController
   def show
     @post = Post.find(params[:id])
   end
+  
   # 投稿削除
   def destroy
     @post = Post.find(params[:id])

--- a/app/controllers/admin/relationships_controller.rb
+++ b/app/controllers/admin/relationships_controller.rb
@@ -4,10 +4,18 @@ class Admin::RelationshipsController < ApplicationController
   def followings
     @user = User.find(params[:id])
     @users = @user.followings.page(params[:page]).per(20).order('users.id DESC')
+    # 退会になると非表示
+    unless @user.is_active
+      redirect_to admin_user_path(@user.id), alert: "指定のユーザーは存在しないか退会済みです。"
+    end
   end
   # フォロワー一覧
   def followers
     @user = User.find(params[:id])
     @users = @user.followers.page(params[:page]).per(20).order('users.id DESC')
+    # 退会になると非表示
+    unless @user.is_active
+      redirect_to admin_user_path(@user.id), alert: "指定のユーザーは存在しないか退会済みです。"
+    end
   end
 end

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -4,7 +4,7 @@ class Admin::UsersController < ApplicationController
   def index
     @users = User.page(params[:page]).per(10)
   end
-  
+
   # ユーザー詳細
   def show
     @user = User.find(params[:id])
@@ -58,12 +58,21 @@ class Admin::UsersController < ApplicationController
   def userpost
     @user = User.find(params[:id])
     @posts = @user.posts.page(params[:page]).per(10).order('id DESC')
+    # 退会になると非表示
+    unless @user.is_active
+      redirect_to admin_user_path(@user.id), alert: "指定のユーザーは存在しないか退会済みです。"
+    end
   end
+  
   # お気に入り投稿一覧
   def favorites
     @user = User.find(params[:id])
     favorites = Favorite.where(user_id: @user.id).pluck(:post_id)
     @favorite_posts = Post.where(id: favorites).page(params[:page]).per(20).order('id DESC')
+    # 退会になると非表示
+    unless @user.is_active
+      redirect_to admin_user_path(@user.id), alert: "指定のユーザーは存在しないか退会済みです。"
+    end
   end
 
   private

--- a/app/controllers/public/favorites_controller.rb
+++ b/app/controllers/public/favorites_controller.rb
@@ -1,7 +1,6 @@
 class Public::FavoritesController < ApplicationController
   # お気に入り登録
   def create
-    
     @post = Post.find(params[:post_id])
     favorite = current_user.favorites.new(post_id: @post.id)
     favorite.save

--- a/app/controllers/public/relationships_controller.rb
+++ b/app/controllers/public/relationships_controller.rb
@@ -16,11 +16,19 @@ class Public::RelationshipsController < ApplicationController
   def followings
     @user = User.find(params[:user_id])
     @users = @user.followings.page(params[:page]).per(10).order('users.id DESC')
+     # 退会になると非表示
+    unless @user.is_active
+      redirect_to user_path(current_user), alert: "指定のユーザーは存在しないか退会済みです。"
+    end
   end
 
   # フォロワーユーザー一覧
   def followers
     @user = User.find(params[:user_id])
     @users = @user.followers.page(params[:page]).per(10).order('users.id DESC')
+     # 退会になると非表示
+    unless @user.is_active
+      redirect_to user_path(current_user), alert: "指定のユーザーは存在しないか退会済みです。"
+    end
   end
 end

--- a/app/controllers/public/users_controller.rb
+++ b/app/controllers/public/users_controller.rb
@@ -1,10 +1,11 @@
 class Public::UsersController < ApplicationController
   before_action :authenticate_user!
   before_action :is_matching_login_user, only:[:edit, :update]
-  before_action :ensure_guest_user, only:[:edit]
+  before_action :ensure_guest_user, only:[:edit, :userpost]
   # ユーザー詳細
   def show
     @user = User.find(params[:id])
+    # 退会になると非表示
     unless @user.is_active
       redirect_to user_path(current_user), alert: "指定のユーザーは存在しないか退会済みです。"
     end
@@ -67,12 +68,20 @@ class Public::UsersController < ApplicationController
     @user = User.find(params[:id])
     favorites = Favorite.where(user_id: @user.id).pluck(:post_id)
     @favorite_posts = Post.where(id: favorites).page(params[:page]).per(10).order('id DESC')
+    # 退会になると非表示
+    unless @user.is_active
+      redirect_to user_path(current_user), alert: "指定のユーザーは存在しないか退会済みです。"
+    end
   end
 
   # ユーザーの全投稿一覧
   def userpost
     @user = User.find(params[:id])
     @posts = @user.posts.page(params[:page]).per(10).order('id DESC')
+    # 退会になると非表示
+    unless @user.is_active
+      redirect_to user_path(current_user), alert: "指定のユーザーは存在しないか退会済みです。"
+    end
   end
 
 


### PR DESCRIPTION
退会ユーザーのフォロー一覧・フォロワー一覧・お気に入り投稿一覧がURLから飛べるようになっていたので修正
管理者側も同じようにページへのアクセスは不要なので退会ユーザーに対しては上記の一覧を表示させないようにした。