### PR TITLE
[Fix]ページネーション等修正

### DIFF
--- a/app/controllers/admin/homes_controller.rb
+++ b/app/controllers/admin/homes_controller.rb
@@ -2,6 +2,6 @@ class Admin::HomesController < ApplicationController
   before_action :authenticate_admin!
   # 投稿一覧
   def top
-    @posts = Post.page(params[:page]).per(30).order('id DESC')
+    @posts = Post.page(params[:page]).per(12).order('id DESC')
   end
 end

--- a/app/controllers/admin/relationships_controller.rb
+++ b/app/controllers/admin/relationships_controller.rb
@@ -3,7 +3,7 @@ class Admin::RelationshipsController < ApplicationController
   # フォロー一覧
   def followings
     @user = User.find(params[:id])
-    @users = @user.followings.page(params[:page]).per(30).order('users.id DESC')
+    @users = @user.followings.page(params[:page]).per(15).order('users.id DESC')
     # 退会になると非表示
     unless @user.is_active
       redirect_to admin_user_path(@user.id), alert: "指定のユーザーは存在しないか退会済みです。"
@@ -12,7 +12,7 @@ class Admin::RelationshipsController < ApplicationController
   # フォロワー一覧
   def followers
     @user = User.find(params[:id])
-    @users = @user.followers.page(params[:page]).per(30).order('users.id DESC')
+    @users = @user.followers.page(params[:page]).per(15).order('users.id DESC')
     # 退会になると非表示
     unless @user.is_active
       redirect_to admin_user_path(@user.id), alert: "指定のユーザーは存在しないか退会済みです。"

--- a/app/controllers/admin/searches_controller.rb
+++ b/app/controllers/admin/searches_controller.rb
@@ -14,9 +14,9 @@ class Admin::SearchesController < ApplicationController
 
     if @model == "user"
       # 投稿住所検索は新着順に表示
-      @records = User.admin_search_for(@content).page(params[:page]).per(30)
+      @records = User.admin_search_for(@content).page(params[:page]).per(15)
     else
-      @records = Post.search_for(@content, @model).page(params[:page]).per(30).order('id DESC')
+      @records = Post.search_for(@content, @model).page(params[:page]).per(12).order('id DESC')
     end
   end
 end

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -2,7 +2,7 @@ class Admin::UsersController < ApplicationController
   before_action :authenticate_admin!
   # ユーザー一覧
   def index
-    @users = User.page(params[:page]).per(30)
+    @users = User.page(params[:page]).per(15)
   end
 
   # ユーザー詳細
@@ -57,7 +57,7 @@ class Admin::UsersController < ApplicationController
   # ユーザーの投稿一覧
   def userpost
     @user = User.find(params[:id])
-    @posts = @user.posts.page(params[:page]).per(30).order('id DESC')
+    @posts = @user.posts.page(params[:page]).per(12).order('id DESC')
     # 退会になると非表示
     unless @user.is_active
       redirect_to admin_user_path(@user.id), alert: "指定のユーザーは存在しないか退会済みです。"
@@ -68,7 +68,7 @@ class Admin::UsersController < ApplicationController
   def favorites
     @user = User.find(params[:id])
     favorites = Favorite.where(user_id: @user.id).pluck(:post_id)
-    @favorite_posts = Post.where(id: favorites).page(params[:page]).per(30).order('id DESC')
+    @favorite_posts = Post.where(id: favorites).page(params[:page]).per(12).order('id DESC')
     # 退会になると非表示
     unless @user.is_active
       redirect_to admin_user_path(@user.id), alert: "指定のユーザーは存在しないか退会済みです。"

--- a/app/controllers/public/notifications_controller.rb
+++ b/app/controllers/public/notifications_controller.rb
@@ -3,7 +3,7 @@ class Public::NotificationsController < ApplicationController
 
   # 通知一覧
   def index
-    @notifications = current_user.notifications.order(created_at: :desc).page(params[:page]).per(30)
+    @notifications = current_user.notifications.order(created_at: :desc).page(params[:page]).per(20)
   end
 
   # 通知の更新

--- a/app/controllers/public/posts_controller.rb
+++ b/app/controllers/public/posts_controller.rb
@@ -65,7 +65,7 @@ class Public::PostsController < ApplicationController
       format.html do
         # 後でフォローしている人と自分の投稿のみ表示にする
         # 新着順
-        @posts = Post.where(user_id: [current_user.id] + current_user.followings.pluck(:id)).page(params[:page]).per(30).order('id DESC')
+        @posts = Post.where(user_id: [current_user.id] + current_user.followings.pluck(:id)).page(params[:page]).per(12).order('id DESC')
       end
       format.json do
         @posts = Post.all

--- a/app/controllers/public/relationships_controller.rb
+++ b/app/controllers/public/relationships_controller.rb
@@ -15,7 +15,7 @@ class Public::RelationshipsController < ApplicationController
   # フォローユーザー一覧
   def followings
     @user = User.find(params[:user_id])
-    @users = @user.followings.page(params[:page]).per(30).order('users.id DESC')
+    @users = @user.followings.page(params[:page]).per(15).order('users.id DESC')
      # 退会になると非表示
     unless @user.is_active
       redirect_to user_path(current_user), alert: "指定のユーザーは存在しないか退会済みです。"
@@ -25,7 +25,7 @@ class Public::RelationshipsController < ApplicationController
   # フォロワーユーザー一覧
   def followers
     @user = User.find(params[:user_id])
-    @users = @user.followers.page(params[:page]).per(30).order('users.id DESC')
+    @users = @user.followers.page(params[:page]).per(15).order('users.id DESC')
      # 退会になると非表示
     unless @user.is_active
       redirect_to user_path(current_user), alert: "指定のユーザーは存在しないか退会済みです。"

--- a/app/controllers/public/searches_controller.rb
+++ b/app/controllers/public/searches_controller.rb
@@ -12,14 +12,13 @@ class Public::SearchesController < ApplicationController
       redirect_to request.referer
       return
     end
-
     # ユーザー検索
     if @model == "user"
       # 投稿住所検索は新着順に表示
-      @records = User.search_for(@content).page(params[:page]).per(30)
+      @records = User.search_for(@content).page(params[:page]).per(15)
     # 投稿住所or投稿郵便番号検索
     else
-      @records = Post.search_for(@content, @model).page(params[:page]).per(30).order('id DESC')
+      @records = Post.search_for(@content, @model).page(params[:page]).per(12).order('id DESC')
     end
   end
 end

--- a/app/controllers/public/users_controller.rb
+++ b/app/controllers/public/users_controller.rb
@@ -67,7 +67,7 @@ class Public::UsersController < ApplicationController
   def favorites
     @user = User.find(params[:id])
     favorites = Favorite.where(user_id: @user.id).pluck(:post_id)
-    @favorite_posts = Post.where(id: favorites).page(params[:page]).per(30).order('id DESC')
+    @favorite_posts = Post.where(id: favorites).page(params[:page]).per(12).order('id DESC')
     # 退会になると非表示
     unless @user.is_active
       redirect_to user_path(current_user), alert: "指定のユーザーは存在しないか退会済みです。"
@@ -77,7 +77,7 @@ class Public::UsersController < ApplicationController
   # ユーザーの全投稿一覧
   def userpost
     @user = User.find(params[:id])
-    @posts = @user.posts.page(params[:page]).per(30).order('id DESC')
+    @posts = @user.posts.page(params[:page]).per(12).order('id DESC')
     # 退会になると非表示
     unless @user.is_active
       redirect_to user_path(current_user), alert: "指定のユーザーは存在しないか退会済みです。"

--- a/app/views/admin/homes/_postindex.html.erb
+++ b/app/views/admin/homes/_postindex.html.erb
@@ -24,7 +24,7 @@
       </div>
       <div class="card-item">
         <%= link_to admin_post_path(post.id) do %>
-          〒<%= post.post_code.to_s.insert(3, "-") %><br>
+          〒<%= post.post_code.slice(0, 3) %>-<%= post.post_code.slice(3, 4) %><br>
           <%= post.prefecture_address %>
           <%= post.city_address %><br>
           <%= post.block_address %>

--- a/app/views/admin/posts/show.html.erb
+++ b/app/views/admin/posts/show.html.erb
@@ -52,7 +52,7 @@
           </tr>
           <tr>
             <th>郵便番号</th>
-            <td>〒<%= @post.post_code.to_s.insert(3, "-") %></td>
+            <td>〒<%= @post.post_code.slice(0, 3) %>-<%= @post.post_code.slice(3, 4) %></td>
           </tr>
           <tr>
             <th class="align-middle">住所</th>

--- a/app/views/admin/searches/search.html.erb
+++ b/app/views/admin/searches/search.html.erb
@@ -22,7 +22,7 @@
     <% else @model =='post_code' %>
     <!--郵便番号の検索結果一覧(完全一致)-->
       <div class="row my-4 justify-content-center text-center">
-        <h4 class="mb-3"><i class="fa-solid fa-magnifying-glass"></i>　郵便番号<strong>"〒<%= @content.to_s.insert(3, "-") %>"</strong>は<br class="hidden-pc"><%= @records.total_count %>件<br class="hidden-pc">見つかりました。</h4>
+        <h4 class="mb-3"><i class="fa-solid fa-magnifying-glass"></i>　郵便番号<strong>"〒<%= @content.slice(0, 3) %>-<%= @content.slice(3, 4) %>"</strong>は<br class="hidden-pc"><%= @records.total_count %>件<br class="hidden-pc">見つかりました。</h4>
       </div>
       <%= render 'admin/homes/postindex', posts: @records %>
     <% end %>

--- a/app/views/public/posts/_timeline.html.erb
+++ b/app/views/public/posts/_timeline.html.erb
@@ -26,7 +26,7 @@
       </div>
       <div class="card-item">
         <%= link_to post_path(post.id) do %>
-          〒<%= post.post_code.to_s.insert(3, "-")%><br>
+          〒<%= post.post_code.slice(0, 3) %>-<%= post.post_code.slice(3, 4) %><br>
           <i class="fa-solid fa-location-dot" style="color: #7a7a7a;"></i>
           <%= post.prefecture_address %>
           <%= post.city_address %><br>

--- a/app/views/public/posts/show.html.erb
+++ b/app/views/public/posts/show.html.erb
@@ -59,7 +59,7 @@
         </tr>
         <tr>
           <th>郵便番号</th>
-          <td>〒<%= @post.post_code.to_s.insert(3, "-") %></td>
+          <td>〒<%= @post.post_code.slice(0, 3) %>-<%= @post.post_code.slice(3, 4) %></td>
         </tr>
         <tr>
           <th class="align-middle">住所</th>

--- a/app/views/public/registrations/new.html.erb
+++ b/app/views/public/registrations/new.html.erb
@@ -1,9 +1,15 @@
 <!--ユーザー新規登録ページ-->
 <div class="container my-3">
-  <!--フラッシュメッセージ-->
+  <!--フラッシュメッセージ(退会ユーザーがログインしようとすると表示)-->
   <% flash.each do |message_type, message| %>
     <div class="flash-message <%= message_type %>"><%= message %></div>
   <% end %>
+
+  <!--新規登録でエラー出現時表示-->
+  <% if @user.errors.any? %>
+    <div class="flash-message alert">新規登録に失敗しました。</div>
+  <% end %>
+
   <div class="row no-gutters">
     <div class="col-lg-6 col-md-9 col-sm-10 mx-2 mx-sm-auto text-center shadow-lg rounded my-5">
       <h3 class="session-title rounded py-4 mb-0">新規登録</h3>

--- a/app/views/public/searches/search.html.erb
+++ b/app/views/public/searches/search.html.erb
@@ -21,7 +21,7 @@
     <% else @model =='post_code' %>
     <!--郵便番号の検索結果一覧(完全一致)-->
       <div class="row my-4 justify-content-center text-center">
-        <h4 class="mb-3"><i class="fa-solid fa-magnifying-glass"></i>　郵便番号<strong>"〒<%= @content %>"</strong>は<br class="hidden-pc"><%= @records.total_count %>件<br class="hidden-pc">見つかりました。</h4>
+        <h4 class="mb-3"><i class="fa-solid fa-magnifying-glass"></i>　郵便番号<strong>"〒<%= @content.slice(0, 3) %>-<%= @content.slice(3, 4) %>"</strong>は<br class="hidden-pc"><%= @records.total_count %>件<br class="hidden-pc">見つかりました。</h4>
       </div>
       <%= render 'public/posts/timeline', posts: @records %>
     <% end %>

--- a/app/views/public/users/edit.html.erb
+++ b/app/views/public/users/edit.html.erb
@@ -6,7 +6,12 @@
   <% end %>
   <div class="row no-gutters">
     <div class="col-lg-7 col-md-9 col-sm-10 mx-2 mx-sm-auto text-center shadow-lg rounded my-5">
-      <h3 class="text-dark bg-light rounded py-4 mb-0">ユーザー編集</h3>
+      <h3 class="text-dark bg-light rounded py-4 mb-0">
+        <%= link_to  user_path(@user.id) do %>
+          <i class="fa-solid fa-circle-chevron-left"  style="color: #7a7a7a;"></i>
+        <% end %>
+        ユーザー編集
+      </h3>
       <div class="form-body p-4">
         <!--バリデーションエラーメッセージ-->
         <div>

--- a/config/initializers/kaminari_config.rb
+++ b/config/initializers/kaminari_config.rb
@@ -3,7 +3,7 @@
 Kaminari.configure do |config|
   # config.default_per_page = 25
   # config.max_per_page = nil
-  # config.window = 4
+  config.window = 1
   # config.outer_window = 0
   # config.left = 0
   # config.right = 0

--- a/config/locales/devise.ja.yml
+++ b/config/locales/devise.ja.yml
@@ -1,6 +1,8 @@
 ja:
   activerecord:
     attributes:
+      admin:
+        email: メールアドレス
       user:
         confirmation_sent_at: パスワード確認送信時刻
         confirmation_token: パスワード確認用トークン

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,4 +1,11 @@
 ja:
+  views:
+    pagination:
+      first: "<<"
+      last: ">>"
+      previous: "<"
+      next: ">"
+      truncate: "..."
   enums:
     post:
       status:


### PR DESCRIPTION
ユーザー：新規登録失敗時フラッシュメッセージ表示
管理者：メッセージをemail→メールアドレスに変更

ブートストラップ修正
郵便番号記述変更
ページ表示件数変更